### PR TITLE
DEL-1174 Add basic NATS support and start to work out Okta integration

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,9 @@ func init() {
 
 	rootCmd.PersistentFlags().Bool("pretty", false, "enable pretty (human readable) logging output")
 	viperBindFlag("logging.pretty", rootCmd.PersistentFlags().Lookup("pretty"))
+
+	rootCmd.PersistentFlags().Bool("development", false, "enable development settings")
+	viperBindFlag("development", rootCmd.PersistentFlags().Lookup("development"))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -6,8 +6,10 @@ import (
 	"os/signal"
 
 	audithelpers "github.com/metal-toolbox/auditevent/helpers"
+	"github.com/nats-io/nats.go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"go.equinixmetal.net/gov-okta-addon/internal/okta"
 	"go.equinixmetal.net/gov-okta-addon/internal/srv"
 )
 
@@ -26,6 +28,18 @@ func init() {
 	serveCmd.Flags().String("listen", "0.0.0.0:8000", "address to listen on")
 	viperBindFlag("listen", serveCmd.Flags().Lookup("listen"))
 
+	serveCmd.Flags().String("nats-url", "nats://127.0.0.1:4222", "NATS server connection url")
+	viperBindFlag("nats.url", serveCmd.Flags().Lookup("nats-url"))
+
+	serveCmd.Flags().String("nats-token", "", "NATS auth token")
+	viperBindFlag("nats.token", serveCmd.Flags().Lookup("nats-token"))
+
+	serveCmd.Flags().String("nats-subject-prefix", "equinixmetal.governor.addons", "prefix for NATS subjects")
+	viperBindFlag("nats.subject-prefix", serveCmd.Flags().Lookup("nats-subject-prefix"))
+
+	serveCmd.Flags().String("nats-queue-group", "equinixmetal.governor.addons.gov-okta-addon", "queue group for load balancing messages across NATS consumers")
+	viperBindFlag("nats.queue-group", serveCmd.Flags().Lookup("nats-queue-group"))
+
 	// Tracing Flags
 	serveCmd.Flags().Bool("tracing", false, "enable tracing support")
 	viperBindFlag("tracing.enabled", serveCmd.Flags().Lookup("tracing"))
@@ -38,6 +52,12 @@ func init() {
 
 	serveCmd.Flags().String("audit-log-path", "/app-audit/audit.log", "file path to write audit logs to.")
 	viperBindFlag("audit.log-path", serveCmd.Flags().Lookup("audit-log-path"))
+
+	// Okta related flags
+	serveCmd.Flags().String("okta-url", "https://equinixmetal.okta.com", "url for Okta client calls")
+	viperBindFlag("okta.url", serveCmd.Flags().Lookup("okta-url"))
+	serveCmd.Flags().String("okta-token", "", "token for access to the Okta API")
+	viperBindFlag("okta.token", serveCmd.Flags().Lookup("okta-token"))
 }
 
 func serve(cmdCtx context.Context, v *viper.Viper) error {
@@ -67,11 +87,37 @@ func serve(cmdCtx context.Context, v *viper.Viper) error {
 	}
 	defer auf.Close()
 
+	nc, err := newNATSConnection()
+	if err != nil {
+		logger.Fatalw("failed to create NATS client connection", "error", err)
+	}
+
+	natsClient, err := srv.NewNATSClient(
+		srv.WithNATSLogger(logger.Desugar()),
+		srv.WithNATSConn(nc),
+		srv.WithNATSPrefix(viper.GetString("nats.subject-prefix")),
+		srv.WithNATSQueueGroup(viper.GetString(("nats.queue-group"))),
+	)
+	if err != nil {
+		logger.Fatalw("failed creating new NATS client", "error", err)
+	}
+
+	oc, err := okta.NewClient(
+		okta.WithLogger(logger.Desugar()),
+		okta.WithURL(viper.GetString("okta.url")),
+		okta.WithToken(viper.GetString("okta.token")),
+	)
+	if err != nil {
+		return err
+	}
+
 	server := &srv.Server{
 		Debug:           viper.GetBool("logging.debug"),
 		Listen:          viper.GetString("listen"),
 		Logger:          logger.Desugar(),
 		AuditFileWriter: auf,
+		NATSClient:      natsClient,
+		OktaClient:      oc,
 	}
 
 	logger.Infow("starting server", "address", viper.GetString("listen"))
@@ -81,4 +127,21 @@ func serve(cmdCtx context.Context, v *viper.Viper) error {
 	}
 
 	return nil
+}
+
+// newNATSConnection creates a new NATS connection
+// TODO: modify for auth/tls settings once we finalize NATS deployment details
+func newNATSConnection() (*nats.Conn, error) {
+	opts := []nats.Option{
+		nats.Token(viper.GetString("nats.token")),
+	}
+
+	if viper.GetBool("development") {
+		logger.Debug("enabling development settings")
+	}
+
+	return nats.Connect(
+		viper.GetString("nats-url"),
+		opts...,
+	)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,18 @@ services:
     - serve
     - --debug
     - --pretty
+    - --development
     - --audit-log-path=/app-audit/audit.log
+    environment:
+      GOA_NATS_URL: nats://nats-server:4222
+      GOA_NATS_TOKEN: topSecret111
+      GOA_OKTA_TOKEN: ${GOA_OKTA_TOKEN}
     ports:
       - "8000:8000"
     restart: unless-stopped
     depends_on:
       - audit
+      - nats-server
     networks:
       - gov-okta-addon
     volumes:
@@ -30,6 +36,18 @@ services:
         target: /app-audit
         read_only: false
     restart: unless-stopped
+
+  nats-server:
+    image: nats:latest
+    command:
+      - -D
+      - --auth
+      - topSecret111
+    ports:
+      - "4222:4222"
+    restart: unless-stopped
+    networks:
+      - gov-okta-addon
 
 volumes:
   audit-log:

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,10 @@ require (
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-contrib/zap v0.0.2
 	github.com/gin-gonic/gin v1.8.1
+	github.com/goccy/go-json v0.9.7
 	github.com/metal-toolbox/auditevent v0.1.10
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/nats-io/nats.go v1.16.0
 	github.com/okta/okta-sdk-golang/v2 v2.13.0
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5
@@ -35,7 +37,6 @@ require (
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/go-playground/validator/v10 v10.10.1 // indirect
-	github.com/goccy/go-json v0.9.7 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
@@ -48,6 +49,9 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/nats-io/nats-server/v2 v2.8.4 // indirect
+	github.com/nats-io/nkeys v0.3.0 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,7 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.14.4 h1:eijASRJcobkVtSt81Olfh7JX43osYLwy5krOJo6YEu4=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
@@ -233,6 +234,7 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/metal-toolbox/auditevent v0.1.10 h1:6SewVHg0fSF7rtaatDFj8mdUNV9dfRInaD7A+8O4mp4=
 github.com/metal-toolbox/auditevent v0.1.10/go.mod h1:897R8dNJtXRuc/TsDrKcSBLsYM9BGhPqgS8HklVOLTY=
+github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
@@ -246,6 +248,15 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/nats-io/jwt/v2 v2.2.1-0.20220330180145-442af02fd36a h1:lem6QCvxR0Y28gth9P+wV2K/zYUUAkJ+55U8cpS0p5I=
+github.com/nats-io/nats-server/v2 v2.8.4 h1:0jQzze1T9mECg8YZEl8+WYUXb9JKluJfCBriPUtluB4=
+github.com/nats-io/nats-server/v2 v2.8.4/go.mod h1:8zZa+Al3WsESfmgSs98Fi06dRWLH5Bnq90m5bKD/eT4=
+github.com/nats-io/nats.go v1.16.0 h1:zvLE7fGBQYW6MWaFaRdsgm9qT39PJDQoju+DS8KsO1g=
+github.com/nats-io/nats.go v1.16.0/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
+github.com/nats-io/nkeys v0.3.0 h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=
+github.com/nats-io/nkeys v0.3.0/go.mod h1:gvUNGjVcM2IPr5rCsRsC6Wb3Hr2CQAm08dsxtV6A5y4=
+github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
+github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/okta/okta-sdk-golang/v2 v2.13.0 h1:Z5fmqKcFqJCJ1GCRVezElYqUgeL+8jrPybO7nVJjAm0=
 github.com/okta/okta-sdk-golang/v2 v2.13.0/go.mod h1:aL3K0likfyLVapi33OsegX+KJf4c6SDapDhlUcXFEvk=
 github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627 h1:pSCLCl6joCFRnjpeojzOpEYs4q7Vditq8fySFG5ap3Y=
@@ -373,6 +384,7 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
@@ -544,6 +556,7 @@ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 h1:GZokNIeuVkl3aZHJchRrr13WCsols02MLUcz1U9is6M=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/internal/okta/doc.go
+++ b/internal/okta/doc.go
@@ -1,0 +1,2 @@
+// Package okta provides an interface to the okta API
+package okta

--- a/internal/okta/errors.go
+++ b/internal/okta/errors.go
@@ -1,0 +1,10 @@
+package okta
+
+import "errors"
+
+var (
+	// ErrUnexpectedGroupsCount is returned when we get an unexpected number of groups, usually != 1
+	ErrUnexpectedGroupsCount = errors.New("unexpected number of groups returned")
+	// ErrUnexpectedUsersCount is returned when we get an unexpected number of users, usually != 1
+	ErrUnexpectedUsersCount = errors.New("unexpected number of users returned")
+)

--- a/internal/okta/groups.go
+++ b/internal/okta/groups.go
@@ -1,0 +1,115 @@
+package okta
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+	"go.uber.org/zap"
+)
+
+// CreateGroup creates a simple group in Okta with a name, description and an extended schema profile
+func (c *Client) CreateGroup(ctx context.Context, name, desc string, profile map[string]interface{}) (string, error) {
+	c.logger.Info("creating Okta group",
+		zap.String("okta.group.name", name),
+		zap.String("okta.group.description", desc),
+		zap.Any("okta.group.profile", profile),
+	)
+
+	group, _, err := c.groupIface.CreateGroup(ctx, okta.Group{
+		Profile: &okta.GroupProfile{
+			Name:            name,
+			Description:     desc,
+			GroupProfileMap: okta.GroupProfileMap(profile),
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	c.logger.Debug("created okta group", zap.String("okta.group.id", group.Id))
+
+	return group.Id, nil
+}
+
+// UpdateGroup updates a group in Okta
+func (c *Client) UpdateGroup(ctx context.Context, id, name, desc string, profile map[string]interface{}) error {
+	c.logger.Info("updating Okta group",
+		zap.String("okta.group.id", id),
+		zap.String("okta.group.name", name),
+		zap.String("okta.group.description", desc),
+		zap.Any("okta.group.profile", profile),
+	)
+
+	if _, _, err := c.groupIface.UpdateGroup(ctx, id, okta.Group{
+		Profile: &okta.GroupProfile{
+			Name:            name,
+			Description:     desc,
+			GroupProfileMap: okta.GroupProfileMap(profile),
+		},
+	}); err != nil {
+		return err
+	}
+
+	c.logger.Debug("updated okta group", zap.String("okta.group.id", id))
+
+	return nil
+}
+
+// DeleteGroup deletes a group in Okta
+func (c *Client) DeleteGroup(ctx context.Context, id string) error {
+	c.logger.Info("deleting Okta group", zap.String("okta.group.id", id))
+
+	if _, err := c.groupIface.DeleteGroup(ctx, id); err != nil {
+		return err
+	}
+
+	c.logger.Debug("deleted okta group", zap.String("okta.group.id", id))
+
+	return nil
+}
+
+// GetGroupByGovernorID gets an okta group ID from the governor id by searching for the profile field
+func (c *Client) GetGroupByGovernorID(ctx context.Context, id string) (string, error) {
+	c.logger.Info("getting group by governor id", zap.String("governor.id", id))
+
+	f := fmt.Sprintf("profile.governor_id eq %s", id)
+
+	groups, _, err := c.groupIface.ListGroups(ctx, &query.Params{Search: f})
+	if err != nil {
+		return "", err
+	}
+
+	if len(groups) != 1 {
+		return "", ErrUnexpectedGroupsCount
+	}
+
+	gid := groups[0].Id
+
+	c.logger.Debug("found okta group by governor id", zap.String("governor.id", id), zap.String("okta.group.id", gid))
+
+	return gid, nil
+}
+
+// AddGroupUser adds a user to a group by user id and group id
+func (c *Client) AddGroupUser(ctx context.Context, groupID, userID string) error {
+	c.logger.Info("adding user to okta group", zap.String("okta.user.id", userID), zap.String("okta.group.id", groupID))
+
+	if _, err := c.groupIface.AddUserToGroup(ctx, groupID, userID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RemoveGroupUser removes a user from a group by user id and group id
+func (c *Client) RemoveGroupUser(ctx context.Context, groupID, userID string) error {
+	c.logger.Info("removing user from okta group", zap.String("okta.user.id", userID), zap.String("okta.group.id", groupID))
+
+	if _, err := c.groupIface.RemoveUserFromGroup(ctx, groupID, userID); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/okta/groups_test.go
+++ b/internal/okta/groups_test.go
@@ -1,0 +1,370 @@
+package okta
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+type mockGroupClient struct {
+	t   *testing.T
+	err error
+
+	group  *okta.Group
+	groups []*okta.Group
+}
+
+func (m *mockGroupClient) CreateGroup(ctx context.Context, body okta.Group) (*okta.Group, *okta.Response, error) {
+	if m.err != nil {
+		return nil, nil, m.err
+	}
+
+	return m.group, nil, nil
+}
+
+func (m *mockGroupClient) UpdateGroup(ctx context.Context, groupID string, body okta.Group) (*okta.Group, *okta.Response, error) {
+	if m.err != nil {
+		return nil, nil, m.err
+	}
+
+	return m.group, nil, nil
+}
+
+func (m *mockGroupClient) DeleteGroup(ctx context.Context, groupID string) (*okta.Response, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	return nil, nil
+}
+
+func (m *mockGroupClient) ListGroups(ctx context.Context, qp *query.Params) ([]*okta.Group, *okta.Response, error) {
+	if m.err != nil {
+		return nil, nil, m.err
+	}
+
+	return m.groups, nil, nil
+}
+
+func (m *mockGroupClient) AddUserToGroup(ctx context.Context, groupID string, userID string) (*okta.Response, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	return nil, nil
+}
+
+func (m *mockGroupClient) RemoveUserFromGroup(ctx context.Context, groupID string, userID string) (*okta.Response, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	return nil, nil
+}
+
+func TestClient_CreateGroup(t *testing.T) {
+	type args struct {
+		name    string
+		desc    string
+		profile map[string]interface{}
+	}
+
+	tests := []struct {
+		name    string
+		err     error
+		args    args
+		group   *okta.Group
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "example create group",
+			group: &okta.Group{Id: "11111111"},
+			args: args{
+				name:    "testgroup",
+				desc:    "my test group",
+				profile: map[string]interface{}{"governor_id": "abc123"},
+			},
+			want: "11111111",
+		},
+		{
+			name:  "okta error",
+			group: &okta.Group{Id: "11111111"},
+			args: args{
+				name:    "testgroup",
+				desc:    "my test group",
+				profile: map[string]interface{}{"governor_id": "abc123"},
+			},
+			err:     errors.New("boom"), //nolint:goerr113
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				groupIface: &mockGroupClient{
+					t:     t,
+					err:   tt.err,
+					group: tt.group,
+				},
+				logger: zap.NewNop(),
+			}
+			got, err := c.CreateGroup(context.TODO(), tt.args.name, tt.args.desc, tt.args.profile)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestClient_UpdateGroup(t *testing.T) {
+	type args struct {
+		id      string
+		name    string
+		desc    string
+		profile map[string]interface{}
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		err     error
+		wantErr bool
+	}{
+		{
+			name: "example update group",
+			args: args{
+				id:      "11111111",
+				name:    "testgroup",
+				desc:    "my test group",
+				profile: map[string]interface{}{"governor_id": "abc123"},
+			},
+		},
+		{
+			name: "okta error",
+			args: args{
+				id:      "11111111",
+				name:    "testgroup",
+				desc:    "my test group",
+				profile: map[string]interface{}{"governor_id": "abc123"},
+			},
+			err:     errors.New("boom"), //nolint:goerr113
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				groupIface: &mockGroupClient{
+					t:   t,
+					err: tt.err,
+				},
+				logger: zap.NewNop(),
+			}
+			err := c.UpdateGroup(context.TODO(), tt.args.id, tt.args.name, tt.args.desc, tt.args.profile)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestClient_DeleteGroup(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      string
+		err     error
+		wantErr bool
+	}{
+		{
+			name: "example update group",
+			id:   "11111111",
+		},
+		{
+			name:    "okta error",
+			id:      "11111111",
+			err:     errors.New("boom"), //nolint:goerr113
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				groupIface: &mockGroupClient{
+					t:   t,
+					err: tt.err,
+				},
+				logger: zap.NewNop(),
+			}
+			err := c.DeleteGroup(context.TODO(), tt.id)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestClient_GetGroupByGovernorID(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      string
+		groups  []*okta.Group
+		err     error
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "example create group",
+			groups: []*okta.Group{
+				{Id: "11111111"},
+			},
+			id:   "2222222",
+			want: "11111111",
+		},
+		{
+			name: "okta error",
+			groups: []*okta.Group{
+				{Id: "11111111"},
+			},
+			id:      "2222222",
+			err:     errors.New("boom"), //nolint:goerr113
+			wantErr: true,
+		},
+		{
+			name:    "empty list",
+			groups:  []*okta.Group{},
+			id:      "2222222",
+			wantErr: true,
+		},
+		{
+			name: "more than one group returned",
+			groups: []*okta.Group{
+				{Id: "11111111"},
+				{Id: "33333333"},
+			},
+			id:      "2222222",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				groupIface: &mockGroupClient{
+					t:      t,
+					err:    tt.err,
+					groups: tt.groups,
+				},
+				logger: zap.NewNop(),
+			}
+			got, err := c.GetGroupByGovernorID(context.TODO(), tt.id)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestClient_AddGroupUser(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		groupID string
+		userID  string
+		wantErr bool
+	}{
+		{
+			name:    "example add user to group",
+			groupID: "11111111",
+			userID:  "22222222",
+		},
+		{
+			name:    "okta error",
+			groupID: "11111111",
+			userID:  "22222222",
+			err:     errors.New("boom"), //nolint:goerr113
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				groupIface: &mockGroupClient{
+					t:   t,
+					err: tt.err,
+				},
+				logger: zap.NewNop(),
+			}
+
+			err := c.AddGroupUser(context.TODO(), tt.groupID, tt.userID)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestClient_RemoveGroupUser(t *testing.T) {
+	tests := []struct {
+		name    string
+		groupID string
+		userID  string
+		err     error
+		wantErr bool
+	}{
+		{
+			name:    "example add user to group",
+			groupID: "11111111",
+			userID:  "22222222",
+		},
+		{
+			name:    "okta error",
+			groupID: "11111111",
+			userID:  "22222222",
+			err:     errors.New("boom"), //nolint:goerr113
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				groupIface: &mockGroupClient{
+					t:   t,
+					err: tt.err,
+				},
+				logger: zap.NewNop(),
+			}
+
+			err := c.RemoveGroupUser(context.TODO(), tt.groupID, tt.userID)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/internal/okta/okta.go
+++ b/internal/okta/okta.go
@@ -1,0 +1,83 @@
+package okta
+
+import (
+	"context"
+
+	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+	"go.uber.org/zap"
+)
+
+// Client is a client that can talk to Okta
+type Client struct {
+	groupIface GroupInterface
+	userIface  UserInterface
+	logger     *zap.Logger
+
+	url   string
+	token string
+}
+
+// GroupInterface is the interface for managing groups in Okta
+type GroupInterface interface {
+	CreateGroup(ctx context.Context, body okta.Group) (*okta.Group, *okta.Response, error)
+	UpdateGroup(ctx context.Context, groupID string, body okta.Group) (*okta.Group, *okta.Response, error)
+	DeleteGroup(ctx context.Context, groupID string) (*okta.Response, error)
+	ListGroups(ctx context.Context, qp *query.Params) ([]*okta.Group, *okta.Response, error)
+	AddUserToGroup(ctx context.Context, groupID string, userID string) (*okta.Response, error)
+	RemoveUserFromGroup(ctx context.Context, groupID string, userID string) (*okta.Response, error)
+}
+
+// UserInterface is the interface for managing users in Okta
+type UserInterface interface {
+	ListUsers(ctx context.Context, qp *query.Params) ([]*okta.User, *okta.Response, error)
+}
+
+// Option is a functional configuration option
+type Option func(c *Client)
+
+// WithURL sets the endpoint for okta
+func WithURL(u string) Option {
+	return func(c *Client) {
+		c.url = u
+	}
+}
+
+// WithToken sets the okta token
+func WithToken(t string) Option {
+	return func(c *Client) {
+		c.token = t
+	}
+}
+
+// WithLogger sets logger
+func WithLogger(l *zap.Logger) Option {
+	return func(c *Client) {
+		c.logger = l
+	}
+}
+
+// NewClient returns a new Okta client
+func NewClient(opts ...Option) (*Client, error) {
+	client := Client{
+		logger: zap.NewNop(),
+	}
+
+	for _, opt := range opts {
+		opt(&client)
+	}
+
+	_, c, err := okta.NewClient(
+		context.TODO(),
+		okta.WithOrgUrl(client.url),
+		okta.WithToken(client.token),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	client.groupIface = c.Group
+	client.userIface = c.User
+
+	return &client, nil
+}

--- a/internal/okta/users.go
+++ b/internal/okta/users.go
@@ -1,0 +1,31 @@
+package okta
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+	"go.uber.org/zap"
+)
+
+// GetUserIDByEmail gets an okta user id from the user's email address
+func (c *Client) GetUserIDByEmail(ctx context.Context, email string) (string, error) {
+	c.logger.Info("getting user by email address", zap.String("user.email", email))
+
+	f := fmt.Sprintf("profile.email eq %s", email)
+
+	users, _, err := c.userIface.ListUsers(ctx, &query.Params{Search: f})
+	if err != nil {
+		return "", err
+	}
+
+	if len(users) != 1 {
+		return "", ErrUnexpectedUsersCount
+	}
+
+	uid := users[0].Id
+
+	c.logger.Debug("found okta user by email", zap.String("user.email", email), zap.String("okta.user.id", uid))
+
+	return uid, nil
+}

--- a/internal/okta/users_test.go
+++ b/internal/okta/users_test.go
@@ -1,0 +1,91 @@
+package okta
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+type mockUserClient struct {
+	t   *testing.T
+	err error
+
+	users []*okta.User
+}
+
+func (m *mockUserClient) ListUsers(ctx context.Context, qp *query.Params) ([]*okta.User, *okta.Response, error) {
+	if m.err != nil {
+		return nil, nil, m.err
+	}
+
+	return m.users, nil, nil
+}
+
+func TestClient_GetUserIDByEmail(t *testing.T) {
+	tests := []struct {
+		name    string
+		email   string
+		users   []*okta.User
+		err     error
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "example create group",
+			users: []*okta.User{
+				{Id: "11111111"},
+			},
+			email: "foo@example.com",
+			want:  "11111111",
+		},
+		{
+			name: "okta error",
+			users: []*okta.User{
+				{Id: "11111111"},
+			},
+			email:   "foo@example.com",
+			err:     errors.New("boom"), //nolint:goerr113
+			wantErr: true,
+		},
+		{
+			name:    "empty list",
+			users:   []*okta.User{},
+			email:   "foo@example.com",
+			wantErr: true,
+		},
+		{
+			name: "more than one group returned",
+			users: []*okta.User{
+				{Id: "11111111"},
+				{Id: "33333333"},
+			},
+			email:   "foo@example.com",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				logger: zap.NewNop(),
+				userIface: &mockUserClient{
+					t:     t,
+					err:   tt.err,
+					users: tt.users,
+				},
+			}
+			got, err := c.GetUserIDByEmail(context.TODO(), tt.email)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/srv/msg_handlers.go
+++ b/internal/srv/msg_handlers.go
@@ -1,0 +1,167 @@
+package srv
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/nats-io/nats.go"
+	"go.uber.org/zap"
+)
+
+const (
+	// GovernorEventCreate is the action passed on create events
+	// TODO: this definition should move into governor itself and be imported.
+	GovernorEventCreate = "CREATE"
+	// GovernorEventUpdate is the action passed on update events
+	// TODO: this definition should move into governor itself and be imported.
+	GovernorEventUpdate = "UPDATE"
+	// GovernorEventDelete is the action passed on delete events
+	// TODO: this definition should move into governor itself and be imported.
+	GovernorEventDelete = "DELETE"
+)
+
+// GovernorEvent is an event notification from Governor.
+// TODO: this definition should move into governor itself and be imported.
+type GovernorEvent struct {
+	Version string `json:"version"`
+	Action  string `json:"action"`
+	GroupID string `json:"group_id,omitempty"`
+	UserID  string `json:"user_id,omitempty"`
+}
+
+// groupsMessageHandler handles messages for governor group events
+func (s *Server) groupsMessageHandler(m *nats.Msg) {
+	payload, err := s.unmarshalPayload(m)
+	if err != nil {
+		s.Logger.Warn("unable to unmarshal governor payload", zap.Error(err))
+		return
+	}
+
+	switch payload.Action {
+	case GovernorEventCreate:
+		s.Logger.Info("creating group", zap.String("governor.id", payload.GroupID))
+
+		// TODO get the group from governor API by ID (requires https://packet.atlassian.net/browse/DEL-1236)
+		out, err := s.OktaClient.CreateGroup(context.Background(), "testgroup01", "test group", map[string]interface{}{"governor_id": "12345"})
+		if err != nil {
+			s.Logger.Error("error creating group", zap.Error(err))
+			return
+		}
+
+		s.Logger.Info("successfully created group", zap.String("governor.id", payload.GroupID), zap.String("okta.group.id", out))
+	case GovernorEventUpdate:
+		s.Logger.Info("updating group", zap.String("governor.id", payload.GroupID))
+
+		gid, err := s.OktaClient.GetGroupByGovernorID(context.Background(), payload.GroupID)
+		if err != nil {
+			s.Logger.Error("error getting group by governor id", zap.String("governor.id", payload.GroupID), zap.Error(err))
+			return
+		}
+
+		// TODO get the group from governor API by ID (requires https://packet.atlassian.net/browse/DEL-1236)
+		if err := s.OktaClient.UpdateGroup(context.Background(), gid, "testgroup01", "test group improved", map[string]interface{}{"governor_id": payload.GroupID}); err != nil {
+			s.Logger.Error("error updating group", zap.Error(err))
+			return
+		}
+
+		s.Logger.Info("successfully updated group", zap.String("governor.id", payload.GroupID), zap.String("okta.group.id", gid))
+	case GovernorEventDelete:
+		s.Logger.Info("deleting group", zap.String("governor.id", payload.GroupID))
+
+		// TODO validate the group is deleted from governor API by ID (requires https://packet.atlassian.net/browse/DEL-1236)?
+
+		gid, err := s.OktaClient.GetGroupByGovernorID(context.Background(), payload.GroupID)
+		if err != nil {
+			s.Logger.Error("error getting group by governor id", zap.String("governor.id", payload.GroupID), zap.Error(err))
+			return
+		}
+
+		if err := s.OktaClient.DeleteGroup(context.Background(), gid); err != nil {
+			s.Logger.Error("error deleting group", zap.Error(err))
+			return
+		}
+
+		s.Logger.Info("successfully deleted group", zap.String("governor.id", payload.GroupID), zap.String("okta.group.id", gid))
+	default:
+		s.Logger.Warn("unexpected action in governor event", zap.String("governor.action", payload.Action))
+		return
+	}
+}
+
+// membersMessageHandler handles messages for governor membership events
+func (s *Server) membersMessageHandler(m *nats.Msg) {
+	payload, err := s.unmarshalPayload(m)
+	if err != nil {
+		s.Logger.Warn("unable to unmarshal governor payload", zap.Error(err))
+		return
+	}
+
+	switch payload.Action {
+	case GovernorEventCreate:
+		s.Logger.Info("creating group membership", zap.String("governor.id", payload.GroupID), zap.String("governor.id", payload.UserID))
+
+		// TODO validate the user is a member of the group from governor API (requires https://packet.atlassian.net/browse/DEL-1236)?
+		gid, err := s.OktaClient.GetGroupByGovernorID(context.Background(), payload.GroupID)
+		if err != nil {
+			s.Logger.Error("error getting group by governor id", zap.String("governor.id", payload.GroupID), zap.Error(err))
+			return
+		}
+
+		// TODO get the email address of the user from governor API (requires https://packet.atlassian.net/browse/DEL-1236)
+		uid, err := s.OktaClient.GetUserIDByEmail(context.Background(), "test@example.com")
+		if err != nil {
+			s.Logger.Error("error getting user by email address", zap.String("user.email", "test@example.com"), zap.Error(err))
+			return
+		}
+
+		if err := s.OktaClient.AddGroupUser(context.Background(), gid, uid); err != nil {
+			s.Logger.Error("failed to add user to group", zap.String("user.email", "test@example.com"), zap.String("okta.user.id", uid), zap.String("okta.group.id", gid), zap.Error(err))
+			return
+		}
+
+	case GovernorEventDelete:
+		s.Logger.Info("deleting group", zap.String("governor.id", payload.GroupID), zap.String("governor.id", payload.UserID))
+
+		// TODO validate the user is not a member of the group from governor API (requires https://packet.atlassian.net/browse/DEL-1236)?
+		gid, err := s.OktaClient.GetGroupByGovernorID(context.Background(), payload.GroupID)
+		if err != nil {
+			s.Logger.Error("error getting group by governor id", zap.String("governor.id", payload.GroupID), zap.Error(err))
+			return
+		}
+
+		// TODO get the email address of the user from governor API (requires https://packet.atlassian.net/browse/DEL-1236)
+		uid, err := s.OktaClient.GetUserIDByEmail(context.Background(), "test@example.com")
+		if err != nil {
+			s.Logger.Error("error getting user by email address", zap.String("user.email", "test@example.com"), zap.Error(err))
+			return
+		}
+
+		if err := s.OktaClient.RemoveGroupUser(context.Background(), gid, uid); err != nil {
+			s.Logger.Error("failed to remove user from group", zap.String("user.email", "test@example.com"), zap.String("okta.user.id", uid), zap.String("okta.group.id", gid), zap.Error(err))
+			return
+		}
+	default:
+		s.Logger.Warn("unexpected action in governor event", zap.String("governor.action", payload.Action))
+		return
+	}
+}
+
+// usersMessageHandler handles messages for governor user events
+func (s *Server) usersMessageHandler(m *nats.Msg) {
+	_, err := s.unmarshalPayload(m)
+	if err != nil {
+		s.Logger.Warn("unable to unmarshal governor payload", zap.Error(err))
+		return
+	}
+}
+
+func (s *Server) unmarshalPayload(m *nats.Msg) (*GovernorEvent, error) {
+	s.Logger.Debug("received a message:", zap.String("nats.data", string(m.Data)), zap.String("nats.subject", m.Subject))
+
+	payload := GovernorEvent{}
+	if err := json.Unmarshal(m.Data, &payload); err != nil {
+		return nil, err
+	}
+
+	return &payload, nil
+}

--- a/internal/srv/nats.go
+++ b/internal/srv/nats.go
@@ -1,0 +1,85 @@
+package srv
+
+import (
+	"github.com/nats-io/nats.go"
+	"go.uber.org/zap"
+)
+
+// NATSClient is a NATS client with some configuration
+type NATSClient struct {
+	conn       *nats.Conn
+	logger     *zap.Logger
+	prefix     string
+	queueGroup string
+}
+
+// NATSOption is a functional configuration option for NATS
+type NATSOption func(c *NATSClient)
+
+// NewNATSClient configures and establishes a new NATS client connection
+func NewNATSClient(opts ...NATSOption) (*NATSClient, error) {
+	client := NATSClient{
+		logger: zap.NewNop(),
+	}
+
+	for _, opt := range opts {
+		opt(&client)
+	}
+
+	return &client, nil
+}
+
+// WithNATSConn sets the nats connection
+func WithNATSConn(nc *nats.Conn) NATSOption {
+	return func(c *NATSClient) {
+		c.conn = nc
+	}
+}
+
+// WithNATSPrefix sets the nats subscription prefix
+func WithNATSPrefix(p string) NATSOption {
+	return func(c *NATSClient) {
+		c.prefix = p
+	}
+}
+
+// WithNATSQueueGroup sets the nats subscription queue group
+func WithNATSQueueGroup(q string) NATSOption {
+	return func(c *NATSClient) {
+		c.queueGroup = q
+	}
+}
+
+// WithNATSLogger sets the NATS client logger
+func WithNATSLogger(l *zap.Logger) NATSOption {
+	return func(c *NATSClient) {
+		c.logger = l
+	}
+}
+
+func (s *Server) registerSubscriptionHandlers() error {
+	prefix := s.NATSClient.prefix
+	qg := s.NATSClient.queueGroup
+
+	// Receive groups channel events
+	if _, err := s.NATSClient.conn.QueueSubscribe(prefix+".groups", qg, s.groupsMessageHandler); err != nil {
+		return err
+	}
+
+	// Receive group memberships channel events
+	if _, err := s.NATSClient.conn.QueueSubscribe(prefix+".members", qg, s.membersMessageHandler); err != nil {
+		return err
+	}
+
+	// Receive users channel events
+	if _, err := s.NATSClient.conn.QueueSubscribe(prefix+".users", qg, s.usersMessageHandler); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Server) shutdownSubscriptions() error {
+	// Drain and close the NATS connection
+	return s.NATSClient.conn.Drain()
+}

--- a/internal/srv/nats_test.go
+++ b/internal/srv/nats_test.go
@@ -1,0 +1,54 @@
+package srv
+
+import (
+	"testing"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestServer_unmarshalPayload(t *testing.T) {
+	tests := []struct {
+		name    string
+		message *nats.Msg
+		want    *GovernorEvent
+		wantErr bool
+	}{
+		{
+			name: "example message",
+			message: &nats.Msg{
+				Subject: "foobar",
+				Data:    []byte(`{"version": "v1", "action": "CREATE", "group_id": "12345"}`),
+			},
+			want: &GovernorEvent{
+				Version: "v1",
+				Action:  "CREATE",
+				GroupID: "12345",
+			},
+		},
+		{
+			name: "bad payload",
+			message: &nats.Msg{
+				Subject: "foobar",
+				Data:    []byte(`{`),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{
+				Logger: zap.NewNop(),
+			}
+			got, err := s.unmarshalPayload(tt.message)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This PR starts to flesh out the integration with Okta and the implementation of the eventing system.

* Add basic NATS support for establishing a connection and subscribing to subjects/queue groups
* Adds support for development environments with NATS
* Implements core Okta groups and group membership functionality

Still TODO is establishing production connection patterns for Okta - cluster endpoints, TLS, auth (unless token is acceptable) - these will be follow-up work after the NATS deployment is complete.  Also TODO is completing the governor API endpoints to get data about IDs passed in event messages.