### PR TITLE
Expand tests for Okta applications

### DIFF
--- a/internal/okta/applications.go
+++ b/internal/okta/applications.go
@@ -78,6 +78,10 @@ func (c *Client) listApplications(ctx context.Context, qp *query.Params) ([]okta
 
 // AssignGroupToApplication assigns a group to an okta application
 func (c *Client) AssignGroupToApplication(ctx context.Context, appID, groupID string) error {
+	if appID == "" || groupID == "" {
+		return ErrApplicationBadParameters
+	}
+
 	assignment, _, err := c.appIface.CreateApplicationGroupAssignment(ctx, appID, groupID, okta.ApplicationGroupAssignment{})
 	if err != nil {
 		return err
@@ -90,6 +94,10 @@ func (c *Client) AssignGroupToApplication(ctx context.Context, appID, groupID st
 
 // RemoveApplicationGroupAssignment removes an application group assignment
 func (c *Client) RemoveApplicationGroupAssignment(ctx context.Context, appID, groupID string) error {
+	if appID == "" || groupID == "" {
+		return ErrApplicationBadParameters
+	}
+
 	if _, err := c.appIface.DeleteApplicationGroupAssignment(ctx, appID, groupID); err != nil {
 		return err
 	}
@@ -101,6 +109,10 @@ func (c *Client) RemoveApplicationGroupAssignment(ctx context.Context, appID, gr
 
 // ListGroupApplicationAssignment returns a list of the groups assigned to an application
 func (c *Client) ListGroupApplicationAssignment(ctx context.Context, appID string) ([]string, error) {
+	if appID == "" {
+		return nil, ErrApplicationBadParameters
+	}
+
 	groups := []string{}
 
 	assignments, resp, err := c.appIface.ListApplicationGroupAssignments(ctx, appID, &query.Params{Limit: defaultPageLimit})

--- a/internal/okta/applications_test.go
+++ b/internal/okta/applications_test.go
@@ -79,6 +79,16 @@ func TestClient_AssignGroupToApplication(t *testing.T) {
 			groupID: "39712500-37a8-4102-bce9-432cbe2c28d2",
 		},
 		{
+			name:    "empty appID",
+			groupID: "39712500-37a8-4102-bce9-432cbe2c28d2",
+			wantErr: true,
+		},
+		{
+			name:    "empty groupID",
+			appID:   "14270ca5-ea9f-43b7-a560-f2014399bddc",
+			wantErr: true,
+		},
+		{
 			name:    "error",
 			appID:   "14270ca5-ea9f-43b7-a560-f2014399bddc",
 			groupID: "39712500-37a8-4102-bce9-432cbe2c28d2",
@@ -118,6 +128,16 @@ func TestClient_RemoveApplicationGroupAssignment(t *testing.T) {
 			name:    "example",
 			appID:   "14270ca5-ea9f-43b7-a560-f2014399bddc",
 			groupID: "39712500-37a8-4102-bce9-432cbe2c28d2",
+		},
+		{
+			name:    "empty appID",
+			groupID: "39712500-37a8-4102-bce9-432cbe2c28d2",
+			wantErr: true,
+		},
+		{
+			name:    "empty groupID",
+			appID:   "14270ca5-ea9f-43b7-a560-f2014399bddc",
+			wantErr: true,
 		},
 		{
 			name:    "error",
@@ -170,6 +190,10 @@ func TestClient_ListGroupApplicationAssignment(t *testing.T) {
 			},
 			resp: &okta.Response{},
 			want: []string{"group-001", "group-002"},
+		},
+		{
+			name:    "empty appID",
+			wantErr: true,
 		},
 		{
 			name:    "api error",
@@ -225,6 +249,12 @@ func TestClient_listApplications(t *testing.T) {
 				&okta.Application{Id: "app-02"},
 				&okta.Application{Id: "app-03"},
 			},
+		},
+		{
+			name: "example empty response",
+			resp: &okta.Response{},
+			apps: []okta.App{},
+			want: []okta.App{},
 		},
 		{
 			name:    "api error",
@@ -289,14 +319,14 @@ func TestClient_GithubCloudApplications(t *testing.T) {
 					Settings: &okta.ApplicationSettings{},
 				},
 				&okta.Application{
-					Id: "app-02",
+					Id: "app-05",
 					Settings: &okta.ApplicationSettings{
 						App: &okta.ApplicationSettingsApplication{
 							"githubOrg": []string{"some", "not", "string"},
 						},
 					},
 				},
-				&okta.Application{Id: "app-04"},
+				&okta.Application{Id: "app-06"},
 				&otherApplication{},
 			},
 			want: map[string]string{

--- a/internal/okta/errors.go
+++ b/internal/okta/errors.go
@@ -9,4 +9,6 @@ var (
 	ErrUnexpectedGroupsCount = errors.New("unexpected number of groups returned")
 	// ErrUnexpectedUsersCount is returned when we get an unexpected number of users, usually != 1
 	ErrUnexpectedUsersCount = errors.New("unexpected number of users returned")
+	// ErrApplicationBadParameters is returned when bad parameters are not passed to an app request
+	ErrApplicationBadParameters = errors.New("application request bad parameters")
 )


### PR DESCRIPTION
Minor cleanup and filling out some tests for the okta applications related code.  I split this out of another change set that was getting too big.