### PR TITLE
Fixup selector for group delete

### DIFF
--- a/cmd/sync_groups.go
+++ b/cmd/sync_groups.go
@@ -376,17 +376,17 @@ func deleteOrphanGovernorGroups(ctx context.Context, gc *governor.Client, gIDs m
 	deleted := []string{}
 
 	for _, group := range groups {
+		if !strings.HasPrefix(strings.ToLower(group.Name), strings.ToLower(selectorPrefix)) {
+			l.Debug("skipping delete of non-selected group",
+				zap.String("governor.group.id", group.ID),
+				zap.String("governor.group.name", group.Name),
+				zap.String("governor.group.slug", group.Slug),
+			)
+
+			continue
+		}
+
 		if _, ok := gIDs[group.ID]; !ok {
-			if !strings.HasPrefix(strings.ToLower(group.Slug), strings.ToLower(selectorPrefix)) {
-				l.Debug("skipping delete of non-selected group",
-					zap.String("governor.group.id", group.ID),
-					zap.String("governor.group.name", group.Name),
-					zap.String("governor.group.slug", group.Slug),
-				)
-
-				continue
-			}
-
 			l.Info("deleting orphaned group from governor",
 				zap.String("governor.group.id", group.ID),
 				zap.String("governor.group.name", group.Name),


### PR DESCRIPTION
Prefix selector for creation is group name, so the deletion should be group name as well.  Also there's no reason to evaluate expected groups if we're skipping a group based on prefix.... so lets be moar smarter.