### PR TITLE
Remove unused skipdelete property on server

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -176,7 +176,6 @@ func serve(cmdCtx context.Context, v *viper.Viper) error {
 	server := &srv.Server{
 		Debug:           viper.GetBool("logging.debug"),
 		DryRun:          viper.GetBool("dryrun"),
-		SkipDelete:      viper.GetBool("skip-delete"),
 		Listen:          viper.GetString("listen"),
 		Logger:          logger.Desugar(),
 		AuditFileWriter: auf,
@@ -188,7 +187,7 @@ func serve(cmdCtx context.Context, v *viper.Viper) error {
 	logger.Infow("starting server",
 		"address", viper.GetString("listen"),
 		"dryrun", server.DryRun,
-		"skip-delete", server.SkipDelete,
+		"skip-delete", viper.GetBool("skip-delete"),
 		"governor-url", viper.GetString("governor.url"),
 		"okta-url", viper.GetString("okta.url"),
 	)

--- a/internal/srv/server.go
+++ b/internal/srv/server.go
@@ -27,7 +27,6 @@ type Server struct {
 	Listen          string
 	Debug           bool
 	DryRun          bool
-	SkipDelete      bool
 	AuditFileWriter io.Writer
 	NATSClient      *NATSClient
 	OktaClient      *okta.Client


### PR DESCRIPTION
This property isn't used anywhere (the functional one is on the `Reconciler`).  Removing.