### PR TITLE
Skip app groups when doing a group sync

### DIFF
--- a/cmd/sync_groups.go
+++ b/cmd/sync_groups.go
@@ -99,6 +99,14 @@ func syncGroupsToGovernor(ctx context.Context) error {
 
 		l = l.With(zap.String("okta.group.name", groupName))
 
+		if g.Type == "APP_GROUP" {
+			l.Info("skipping app group")
+
+			skipped++
+
+			return nil, nil
+		}
+
 		if !strings.HasPrefix(strings.ToLower(groupName), strings.ToLower(selectorPrefix)) {
 			l.Info("skipping non-selected group")
 
@@ -252,7 +260,7 @@ func linkGovernorGroupOrganizations(
 		// ensure governor manages the org, otherwise skip over it
 		org, ok := govOrgs[orgName]
 		if !ok {
-			l.Warn("assigned application org doesn't exist as a governor organization",
+			l.Info("assigned application org doesn't exist as a governor organization",
 				zap.String("okta.application.org", orgName),
 			)
 
@@ -363,7 +371,7 @@ func groupFromGroupSlug(ctx context.Context, gc *governor.Client, slug string, l
 			return nil, err
 		}
 
-		l.Warn("group slug not found in governor", zap.String("governor.id", slug))
+		l.Info("group slug not found in governor", zap.String("governor.id", slug))
 
 		return nil, nil
 	}

--- a/cmd/sync_members.go
+++ b/cmd/sync_members.go
@@ -176,7 +176,7 @@ func syncGroup(ctx context.Context, gc *governor.Client, oc *okta.Client, g *v1a
 		user, err := governorUserFromOktaID(ctx, gc, oktaMemberUserID, l)
 		if err != nil {
 			if errors.Is(err, ErrUserNotFound) {
-				l.Warn("user not found in governor, skipping",
+				l.Info("user not found in governor, skipping",
 					zap.String("okta.user.id", oktaMemberUserID),
 					zap.Error(err),
 				)


### PR DESCRIPTION
We should always skip Okta groups of type `APP_GROUP` as they are managed by other apps