### PR TITLE
ci: Use cosign plugin to sign container images.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,6 +55,9 @@ steps:
           push: true
           build-args:
             - NAME=${APP_NAME}
+      - equinixmetal-buildkite/cosign#main:
+          image: "${IMAGE_REPO}:${IMAGE_TAG}"
+          keyless: true
       - equinixmetal-buildkite/trivy#v1.18.3:
           severity: CRITICAL,HIGH
           ignore-unfixed: true


### PR DESCRIPTION
This commit adds the cosign-buildkite-plugin to the CI pipeline. [1] cosign is an open-source tool developed by Chainguard that signs container images, allowing other users to cryptographically verify the origin of container images.

cosign has different operating modes. This commit utilizes Chainguard's signing infrastructure via "keyless signing". [2] Keyless signing makes image signing easy for open-source projects because Chainguard operates the signing infrastructure on behalf of others.

References

1. https://github.com/equinixmetal-buildkite/cosign-buildkite-plugin
2. https://edu.chainguard.dev/open-source/sigstore/cosign/an-introduction-to-cosign/#keyless-signing